### PR TITLE
Fix build fail by bootJar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,12 +92,12 @@ configure(byTypePrefix("kotlin") and byTypeHaving("boot")) {
 
 configure(byTypeHaving("boot") and byTypeSuffix("lib")) {
     tasks {
-        withType<BootJar> {
-            enabled = false
-        }
-
         withType<Jar> {
             enabled = true
+        }
+
+        withType<BootJar> {
+            enabled = false
         }
 
         withType<BootRun> {


### PR DESCRIPTION
# Problem

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':coffee:api:client:bootJar'.
> Main class name has not been configured and it could not be resolved

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 5s
30 actionable tasks: 5 executed, 25 up-to-date
```

`bootJar` is not required in `:coffe:api:client`.
